### PR TITLE
FIX for type comparison and minor changes

### DIFF
--- a/R/tracesMethods.R
+++ b/R/tracesMethods.R
@@ -162,7 +162,7 @@ plot.traces <- function(traces,
                         highlight_col=NULL,
                         colorMap=NULL,
                         monomer_MW=TRUE) {
-  
+
   .tracesTest(traces)
   traces.long <- toLongFormat(traces$traces)
   traces.long <- merge(traces.long,traces$fraction_annotation,by.x="fraction",by.y="id")
@@ -170,7 +170,7 @@ plot.traces <- function(traces,
     traces.long$outlier <- gsub("\\(.*?\\)","",traces.long$id) %in% gsub("\\(.*?\\)","",highlight)
     if(!any(traces.long$outlier)) highlight <- NULL
   }
-  
+
   if(colour_by!="id") {
     if(!colour_by %in% names(traces$trace_annotation)){
       stop("colour_by is not availbale in trace_annotation.")
@@ -179,7 +179,7 @@ plot.traces <- function(traces,
     traces.long <- merge(traces.long,isoform_annotation, by.x="id",by.y="id")
     traces.long[,line:=paste0(get(colour_by),id)]
   }
-  
+
   ## Create a reproducible coloring for the peptides plotted
   if(!is.null(colorMap)){
     if(!all(unique(traces.long$id) %in% names(colorMap))){
@@ -195,16 +195,16 @@ plot.traces <- function(traces,
       colorMap <- createGGplotColMap(unique(traces.long$id))
     }
   }
-  
+
   if(colour_by == "id") {
     p <- ggplot(traces.long) +
       geom_line(aes_string(x='fraction', y='intensity', colour='id', group='id'))
   } else {
-    
+
     p <- ggplot(traces.long) +
       geom_line(aes_string(x='fraction', y='intensity', colour=colour_by, group='line'))
   }
-  
+
   p <- p + xlab('fraction') +
     ylab('intensity') +
     theme_bw() +
@@ -225,7 +225,7 @@ plot.traces <- function(traces,
       p <- p + theme(legend.position="bottom", legend.text=element_text(size = 5), legend.title = element_blank())
     }
   }
-  
+
   if(!is.null(highlight)){
     legend_peps <- unique(traces.long[outlier == TRUE, id])
     if(is.null(highlight_col)){
@@ -250,7 +250,7 @@ plot.traces <- function(traces,
       # geom_line(aes_string(x='fraction', y='intensity', color='id'))
     }
   }
-  
+
   if ("molecular_weight" %in% names(traces$fraction_annotation)) {
     fraction_ann <- traces$fraction_annotation
     tr <- lm(log(fraction_ann$molecular_weight) ~ fraction_ann$id)
@@ -293,7 +293,7 @@ plot.traces <- function(traces,
                                 labels=seq(min(traces$fraction_annotation$id),
                                            max(traces$fraction_annotation$id),10))
   }
-  
+
   if(PDF){
     pdf(paste0(name,".pdf"), height = 6, width = 8)
   }
@@ -346,7 +346,7 @@ summary.traces <- function(traces) {
 #' @param traces Object of class traces.
 #' @param type Character string specifying whether a specific type of traces is required.
 #' The two options are "peptide" or "protein". Default is \code{NULL},
-#' meaning that no specific type is required.
+#' Added test for type equality
 .tracesTest <- function(traces,type=NULL){
   if (! class(traces)=="traces") {
     stop("Object is not of class traces.")
@@ -360,7 +360,12 @@ summary.traces <- function(traces) {
     }
   }
   if (! identical(traces$traces$id,traces$trace_annotation$id)) {
-    stop("IDs in traces and trace_annotation are not identical.")
+  	if (type(traces$traces$id) != type(traces$trace_annotation$id)) {
+  	  stop("IDs in traces and trace_annotation have different types")
+  	}
+  	else{
+      stop("IDs in traces and trace_annotation are not identical.")
+    }
   }
   if (! identical(names(traces$traces),c(traces$fraction_annotation$id,"id"))) {
     stop("Fractions in traces and fraction_annotation are not identical.")


### PR DESCRIPTION
I modified the following.

1. Add test for type equality in .tracesTest. If read input table is it possible to have conversion to factor for both traces$traces$id and traces$trace_annotation$id, however during import there is type conversion from factor to character with the results that .tracesTest fail. Now there is an explicit error for this

2. in ImportFromOpenSwath newer libraries do not have the 1/ which is grep at line 74. Thereby the results is empty. Now error is raised. Another possibility is to add something like
data$ProteinName <- paste("1/",data$ProteinName,sep = "") assuming everything is proteotypic.

3. Changed from sum across charge states to average across charge states in dcast.